### PR TITLE
add Feather to json list

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -1,4 +1,5 @@
 [
+  {"name": "Feather", "url": "https://api.github.com/repos/BetweenWalls/Feather-PD2/contents", "author": "BetweenWalls"},
   {"name": "Kryszard's PD2 Loot Filter", "url": "https://api.github.com/repos/Kryszard-POD/Kryszard-s-PD2-Loot-Filter/contents", "author": "Kryszard"},
   {"name": "Wolfie's Filters", "url": "https://api.github.com/repos/WolfieeifloW/pd2filter/contents", "author": "Wolfie"},
   {"name": "Kryszard's Loot Filter Edit by Gothablo's", "url": "https://api.github.com/repos/Gothablo/FiltrPD2byGothablo/contents", "author": "Gothablo"},


### PR DESCRIPTION
My filter uses ANSI encoding rather than UTF-8 encoding, since the latter doesn't display certain characters correctly. For example, Minor, Lesser, and normal Healing & Mana potions use superscript numbers. (¹²³)