### PR TITLE
Remove Equa1ity

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -1,6 +1,5 @@
 [
   {"name": "Wolfie's Filters", "url": "https://api.github.com/repos/WolfieeifloW/pd2filter/contents", "author": "Wolfie"},
-  {"name": "Equa1ity's Loot Filter", "url": "https://api.github.com/repos/PritchardJasonR/Equa1ityPD2Filter/contents", "author": "Equa1ity"},
   {"name": "TalRasha's PD2 Item Filters", "url": "https://api.github.com/repos/TalRasha125/TalRashas-PD2-Item-Filter/contents", "author": "TalRasha125"},
   {"name": "Kryszard's PD2 Loot Filter", "url": "https://api.github.com/repos/Kryszard-POD/Kryszard-s-PD2-Loot-Filter/contents", "author": "Kryszard"},
   {"name": "Feather", "url": "https://api.github.com/repos/BetweenWalls/Feather-PD2/contents", "author": "BetweenWalls"},


### PR DESCRIPTION
Please Remove My loot filter.

Due to the upcomming %NL% removal I want to be sure I can make the Updates and Proper QA before making my filter public