### PR TITLE
fixed Baneazy URL, removed Dethklok

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -5,7 +5,6 @@
   {"name": "Kryszard's PD2 Loot Filter", "url": "https://api.github.com/repos/Kryszard-POD/Kryszard-s-PD2-Loot-Filter/contents", "author": "Kryszard"},
   {"name": "Feather", "url": "https://api.github.com/repos/BetweenWalls/Feather-PD2/contents", "author": "BetweenWalls"},
   {"name": "TheIrateSeagoer's Loot Filters", "url": "https://api.github.com/repos/TheIrateSeagoer/pd2lootfilter/contents", "author": "TheIrateSeagoer"},
-  {"name": "Baneazy's Loot Filter", "url": "https://api.github.com/repos/PatrickBanez/PD2_Baneazy_Loot_Filter", "author": "Baneazy"},
-  {"name": "Dethklok1637's beginner item filter", "url": "https://api.github.com/repos/PAFaieta/DethkloksPD2itemFIlter/contents", "author": "Dethklok1637"},
+  {"name": "Baneazy's Loot Filter", "url": "https://api.github.com/repos/PatrickBanez/PD2_Baneazy_Loot_Filter/contents", "author": "Baneazy"},
   {"name": "eqN's PD2 Filters", "url": "https://api.github.com/repos/eqNj/eqN-PD2-Filter/contents", "author": "eqN"}
 ]


### PR DESCRIPTION
* Baneazy's filter wasn't showing correctly in the launcher
* Dethklok's filter hasn't been updated since the beginning of season 1, and includes some incorrect codes/formatting