### PR TITLE
fix URL for Baneazy filter

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -5,7 +5,7 @@
   {"name": "Kryszard's PD2 Loot Filter", "url": "https://api.github.com/repos/Kryszard-POD/Kryszard-s-PD2-Loot-Filter/contents", "author": "Kryszard"},
   {"name": "Feather", "url": "https://api.github.com/repos/BetweenWalls/Feather-PD2/contents", "author": "BetweenWalls"},
   {"name": "TheIrateSeagoer's Loot Filters", "url": "https://api.github.com/repos/TheIrateSeagoer/pd2lootfilter/contents", "author": "TheIrateSeagoer"},
-  {"name": "Baneazy's Loot Filter", "url": "https://api.github.com/repos/PatrickBanez/PD2_Baneazy_Loot_Filter", "author": "Baneazy"},
+  {"name": "Baneazy's Loot Filter", "url": "https://api.github.com/repos/PatrickBanez/PD2_Baneazy_Loot_Filter/contents", "author": "Baneazy"},
   {"name": "Dethklok1637's beginner item filter", "url": "https://api.github.com/repos/PAFaieta/DethkloksPD2itemFIlter/contents", "author": "Dethklok1637"},
   {"name": "eqN's PD2 Filters", "url": "https://api.github.com/repos/eqNj/eqN-PD2-Filter/contents", "author": "eqN"}
 ]


### PR DESCRIPTION
The Baneazy filter wasn't being displayed correctly in the launcher